### PR TITLE
Add track of the status changes on a service

### DIFF
--- a/api.go
+++ b/api.go
@@ -56,7 +56,7 @@ func reportsHandler(w http.ResponseWriter, r *http.Request) {
 		j := 1
 		for svc, chk := range svcs {
 			c := map[string]map[string]interface{}{
-				"check": map[string]interface{}{"host": host, "name": svc, "status": statusString(chk.state), "message": chk.output, "timestamp": fmt.Sprint(chk.timestamp)},
+				"check": map[string]interface{}{"host": host, "name": svc, "status": statusString(chk.state), "message": chk.output, "timestamp": fmt.Sprint(chk.timestamp), "statusFirstSeen": fmt.Sprint(chk.statusFirstSeen)},
 				// custom will be used to inject custom-defined fields
 				"custom": getCustomFields(host, svc),
 			}

--- a/cache.go
+++ b/cache.go
@@ -6,11 +6,13 @@ package main
 var cache map[string]map[string]*serviceEntry
 
 // ServiceEntry can be found in the 2nd layer of he map and contains the details
-// of the last status of the check (timestamp, state and plugin output)
+// of the last status of the check (timestamp, timestamp of the last status
+// change, state and plugin output)
 type serviceEntry struct {
-	timestamp uint32
-	state     int16
-	output    string
+	timestamp       uint32
+	statusFirstSeen uint32
+	state           int16
+	output          string
 }
 
 // initCache initialize the cache object
@@ -21,13 +23,21 @@ func initCache() {
 // updateCacheEntry adds or update a given service check result in the cache map
 func updateCacheEntry(hostname, servicename, output string, timestamp uint32, state int16) {
 	svc, ok := cache[hostname]
+	firstSeen := timestamp
 	if !ok {
 		svc = make(map[string]*serviceEntry)
 		cache[hostname] = svc
+	} else if service, exists := svc[servicename]; exists {
+		// If the entry already exists and we update it, we want the time we've seen
+		// the switch to the current status
+		if service.state == state {
+			firstSeen = service.statusFirstSeen
+		}
 	}
 	svc[servicename] = &serviceEntry{
-		timestamp: timestamp,
-		output:    output,
-		state:     state,
+		timestamp:       timestamp,
+		statusFirstSeen: firstSeen,
+		output:          output,
+		state:           state,
 	}
 }

--- a/templates/reports_element.tmpl
+++ b/templates/reports_element.tmpl
@@ -8,5 +8,6 @@
       "status": "{{.check.status}}",
       "message": "{{.check.message}}",
       "lastStatusAt": "{{.check.timestamp}}"
+      "initialStatusAt": "{{.check.statusFirstSeen}}"
     }
   }


### PR DESCRIPTION
This PR keeps the track of the last time the status changed and provides the corresponding timestamp for exposure in the template.
This will help knowing when the status changed last directly in the api.